### PR TITLE
Remove accountability line from homepage

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -95,7 +95,6 @@ const Index = () => {
               <CardContent>
                 <CardDescription className="text-base">
                   Earn +10 points for healthy days, lose -10 for junk food days. 
-                  Miss a day? That's -20 points to keep you accountable.
                 </CardDescription>
               </CardContent>
             </Card>


### PR DESCRIPTION
Remove the '-20 points' accountability line from the home page.

---
<a href="https://cursor.com/background-agent?bcId=bc-baea5178-3fbe-477b-8857-a9d716a0dd6f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-baea5178-3fbe-477b-8857-a9d716a0dd6f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

